### PR TITLE
use correct commit sha when creating the tag

### DIFF
--- a/.github/workflows/test_create_tag_and_branch_on_pr_against_main.yaml
+++ b/.github/workflows/test_create_tag_and_branch_on_pr_against_main.yaml
@@ -32,3 +32,4 @@ jobs:
         with:
           tag: '${{ env.TAG_NAME }}'
           message: '${{ github.event.pull_request.body }}'
+          commit_sha: '${{ github.event.pull_request.head.sha }}'

--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@
   - changed Workflow permissions to "read and write"
   - test with already existing branch
 - test 2: create tag after merging PR against `main`
+  - use correct commit sha


### PR DESCRIPTION
This release uses the correct commit sha when creating the tag.