### PR TITLE
checkout pr head branch instead of main

### DIFF
--- a/.github/workflows/test_create_tag_and_branch_on_pr_against_main.yaml
+++ b/.github/workflows/test_create_tag_and_branch_on_pr_against_main.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: check out repository code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: set env vars
         run: |
@@ -25,7 +27,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           branch: 'refs/heads/prod/${{ env.TAG_NAME }}'
-          sha: '${{ github.event.pull_request.head.sha }}'
+          #sha: '${{ github.event.pull_request.head.sha }}'
 
       - name: create tag
         uses: rickstaa/action-create-tag@v1


### PR DESCRIPTION
This PR checks out the PR head branch and creates a branch and a tag based on this branch, not the main branch.